### PR TITLE
Refactor OAuth2 handling

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/agrski/gitfind/pkg/auth"
 	"github.com/agrski/gitfind/pkg/fetch"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -160,32 +161,21 @@ func isSupportedHost(host fetch.HostName) bool {
 	return false
 }
 
-func getAccessToken(rawAccessToken string, accessTokenFile string) (string, error) {
+func getAccessToken(rawAccessToken string, accessTokenFile string) (oauth2.TokenSource, error) {
+	if isEmpty(accessToken) && isEmpty(accessTokenFile) {
+		return nil, errors.New("must specify either access token or access token file")
+	}
+
 	if !isEmpty(accessToken) && !isEmpty(accessTokenFile) {
-		return "", errors.New("only one of access token and access token file may be specified")
+		return nil, errors.New("only one of access token and access token file may be specified")
 	}
 
-	if !isEmpty(accessTokenFile) {
-		_, err := os.Stat(accessTokenFile)
-		if err != nil {
-			return "", err
-		}
-
-		token, err := os.ReadFile(accessTokenFile)
-		if err != nil {
-			return "", err
-		}
-
-		asString := string(token)
-		asString = strings.TrimSpace(asString)
-		if isEmpty(asString) {
-			return "", errors.New("access token file cannot be empty")
-		}
-
-		return asString, nil
+	tokenSource, err := auth.TokenSourceFromString(rawAccessToken)
+	if err != nil {
+		tokenSource, err = auth.TokenSourceFromFile(accessTokenFile)
 	}
 
-	return rawAccessToken, nil
+	return tokenSource, err
 }
 
 func main() {
@@ -209,12 +199,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	token, err := getAccessToken(accessToken, accessTokenFile)
+	tokenSource, err := getAccessToken(accessToken, accessTokenFile)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	tokenSource := auth.ToTokenSource(token)
 
 	fetcher := fetch.New(l, tokenSource)
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/agrski/gitfind/pkg/auth"
 	"github.com/agrski/gitfind/pkg/fetch"
 )
 
@@ -213,7 +214,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fetcher := fetch.New(l, token)
+	tokenSource := auth.ToTokenSource(token)
+
+	fetcher := fetch.New(l, tokenSource)
 
 	fetcher.Start()
 	fmt.Printf("Searching for %s in %s\n", p, u.String())

--- a/pkg/auth/oauth2.go
+++ b/pkg/auth/oauth2.go
@@ -1,0 +1,13 @@
+package auth
+
+import (
+	"golang.org/x/oauth2"
+)
+
+func ToTokenSource(rawToken string) oauth2.TokenSource {
+	return oauth2.StaticTokenSource(
+		&oauth2.Token{
+			AccessToken: rawToken,
+		},
+	)
+}

--- a/pkg/auth/oauth2.go
+++ b/pkg/auth/oauth2.go
@@ -1,13 +1,41 @@
 package auth
 
 import (
+	"errors"
+	"os"
+	"strings"
+
 	"golang.org/x/oauth2"
 )
 
-func ToTokenSource(rawToken string) oauth2.TokenSource {
+func TokenSourceFromString(rawToken string) (oauth2.TokenSource, error) {
+	if isEmpty(rawToken) {
+		return nil, errors.New("access token cannot be empty")
+	}
+
 	return oauth2.StaticTokenSource(
 		&oauth2.Token{
 			AccessToken: rawToken,
 		},
-	)
+	), nil
+}
+
+func isEmpty(s string) bool {
+	return strings.TrimSpace(s) == ""
+}
+
+func TokenSourceFromFile(fileName string) (oauth2.TokenSource, error) {
+	if isEmpty(fileName) {
+		return nil, errors.New("access token file name must be specified")
+	}
+
+	maybeToken, err := os.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	token := string(maybeToken)
+	token = strings.TrimSpace(token)
+
+	return TokenSourceFromString(token)
 }

--- a/pkg/fetch/fetch.go
+++ b/pkg/fetch/fetch.go
@@ -2,6 +2,7 @@ package fetch
 
 import (
 	"github.com/agrski/gitfind/pkg/fetch/github"
+	"golang.org/x/oauth2"
 )
 
 /*
@@ -26,13 +27,13 @@ type Fetcher interface {
 	Next() (interface{}, bool) // TODO - formalise this return param for interop with matcher
 }
 
-func New(l Location, accessToken string) Fetcher {
+func New(l Location, tokenSource oauth2.TokenSource) Fetcher {
 	githubFetcher := github.New(
 		github.QueryParams{
 			RepoOwner: string(l.Organisation),
 			RepoName:  string(l.Repository),
 		},
-		accessToken,
+		tokenSource,
 	)
 	return githubFetcher
 }

--- a/pkg/fetch/github/github.go
+++ b/pkg/fetch/github/github.go
@@ -34,14 +34,7 @@ type GitHub struct {
 	cancel      func()
 }
 
-func New(q QueryParams, accessToken string) *GitHub {
-	// TODO - refactor OAuth handling entirely outside this package
-	tokenSource := oauth2.StaticTokenSource(
-		&oauth2.Token{
-			AccessToken: accessToken,
-		},
-	)
-
+func New(q QueryParams, tokenSource oauth2.TokenSource) *GitHub {
 	authClient := oauth2.NewClient(context.Background(), tokenSource)
 	client := graphql.NewClient(apiUrl, authClient)
 


### PR DESCRIPTION
Refactor OAuth2 token-source creation into a separate package.
This reduces the responsibilities of the main method and GitHub fetcher, and provides the basis for further authn/authz functionality.