### PR TITLE
ci: Add GitHub Action for Conventional Commit PR title

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check PR title matches Conventional Commit format
-        uses: lab42/conventional-commit@v0.2.0
+        uses: lab42/conventional-commit@v0.2.2
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           require_scope: "true"

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -17,6 +17,7 @@ jobs:
       - name: Check PR title matches Conventional Commit format
         uses: lab42/conventional-commit@v0.2.0
         with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
           require_scope: "true"
           scope_regexp: (\w+)
           description_regexp: ([\w- ]+)

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -27,3 +27,5 @@ jobs:
             refactor
             revert
             test
+        permissions:
+          pull-requests: read

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -18,8 +18,8 @@ jobs:
         uses: lab42/conventional-commit@v0.2.0
         with:
           require_scope: "true"
-          scope_regex: (\w+)
-          description_regex: ([\w- ]+)
+          scope_regexp: (\w+)
+          description_regexp: ([\w- ]+)
           allowed_types: |
             build
             ci

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -20,7 +20,7 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           require_scope: "false"
           scope_regexp: (\w+)
-          description_regexp: ([\w- ]+)
+          description_regexp: "[\w- ]+"
           allowed_types: |
             build
             ci

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,16 @@
+name: lint-pr-title
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title matches Conventional Commit format
+        uses: lab42/conventional-commit@v0.2.0

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -20,7 +20,6 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           require_scope: "false"
           scope_regexp: (\w+)
-          description_regexp: "[\w- ]+"
           allowed_types: |
             build
             ci

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -14,3 +14,16 @@ jobs:
     steps:
       - name: Check PR title matches Conventional Commit format
         uses: lab42/conventional-commit@v0.2.0
+        with:
+          require_scope: "true"
+          scope_regex: (\w+)
+          description_regex: ([\w- ]+)
+          allowed_types: |
+            build
+            ci
+            docs
+            feat
+            fix
+            refactor
+            revert
+            test

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: lab42/conventional-commit@v0.2.2
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          require_scope: "true"
+          require_scope: "false"
           scope_regexp: (\w+)
           description_regexp: ([\w- ]+)
           allowed_types: |

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check PR title matches Conventional Commit format
         uses: lab42/conventional-commit@v0.2.0
@@ -27,5 +29,3 @@ jobs:
             refactor
             revert
             test
-        permissions:
-          pull-requests: read

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -15,17 +15,6 @@ jobs:
       pull-requests: read
     steps:
       - name: Check PR title matches Conventional Commit format
-        uses: lab42/conventional-commit@v0.2.2
+        uses: matthiashermsen/lint-pull-request-title@v1.0.0
         with:
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          require_scope: "false"
-          scope_regexp: (\w+)
-          allowed_types: |
-            build
-            ci
-            docs
-            feat
-            fix
-            refactor
-            revert
-            test
+          allowed-pull-request-types: build,ci,docs,feat,fix,refactor,revert,test


### PR DESCRIPTION
# Why
## Motivation
The [Conventional Commit format](https://www.conventionalcommits.org/en/v1.0.0/) provides a consistent structure for messages, suitable for both human and machine users.  As this repo uses squash commits, enforcing that PR titles match the CC format means all commits merged into `master` will be of this format.  In turn, this makes it easier to quickly grok changes in history and, if so desired, generate a changelog automatically.

## Issues
N/A

# What
## Changes
* Add GitHub workflow for enforcing that PR titles match the Conventional Commit format

## Testing
The action runs against this PR, so ensuring it works has been a gradual process for the PR itself.
