### PR TITLE
ci: Add GitHub Action for golangci-lint

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,0 +1,20 @@
+name: check-code-quality
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  check-code-quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up Golang environment
+        uses: actions/setup-go@v4
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: 1.51.2

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -17,4 +17,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: 1.51.2
+          version: v1.51.2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 run:
   concurrency: 4
-  timeout: 10s
+  timeout: 30s
 
 output:
   sort-results: true


### PR DESCRIPTION
# Why
## Motivation
This ensures that linting is run for every PR, rather than relying on manual runs by the developer.  The same version of `golangci-lint` is used for the GHA workflow as locally to ensure consistent results.

## Issues
N/A

# What
## Changes
* Add GitHub Actions workflow for code quality checks based on `golangci-lint`

## Testing
Linting passes on this PR itself.