### PR TITLE
ci: Add GitHub Action for releasing artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: create-release
 on:
   push:
     tags:
-      - v[0-9].[0-9].[0-9]*
+      - v[0-9]+.[0-9]+.[0-9]+*
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,17 @@
+name: create-release
+on:
+  push:
+    tags:
+      - v[0-9].[0-9].[0-9]*
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up Golang environment
+        uses: actions/setup-go@v4
+      - name: Build artifacts
+        run: make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,4 +14,11 @@ jobs:
       - name: Set up Golang environment
         uses: actions/setup-go@v4
       - name: Build artifacts
-        run: make build
+        run: make build -o lint
+      - name: Create draft release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: bin/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true


### PR DESCRIPTION
# Why
## Motivation
It'd be nice for users to have pre-built binaries available, rather than having to build from source.  The solution provided by this PR is to automatically build binaries and create a release with these whenever a tag is pushed that resembles a (semantic) version.

## Issues
Fixes #5

# What
## Changes
* Add GitHub Actions workflow for (draft) releases

## Testing
N/A - cannot test until the workflow has been detected and is available.
