### PR TITLE
ci: Fix tag pattern in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: create-release
 on:
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+*
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 jobs:
   create-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Why
## Motivation
Due to YAML parsing, the tag pattern requires surrounding quotes.  See [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) for details.

## Issues
Fixes #5 

# What
## Changes
* Add quotes around tag pattern in release workflow

## Testing
N/A
