### PR TITLE
build(lint): Add linter resource usage stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 
 .PHONY:lint
 lint:
-	golangci-lint run --verbose --print-resources-usage
+	golangci-lint run --verbose
 
 .PHONY:build
 build: build-cli

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 
 .PHONY:lint
 lint:
-	golangci-lint run
+	golangci-lint run --verbose --print-resources-usage
 
 .PHONY:build
 build: build-cli


### PR DESCRIPTION
# Why
## Motivation
This information provides context on what `golangci-lint` is doing and what resource consumption it expects.

# What
## Changes
* Add CLI args for `golangci-lint` to output resource consumption

## Testing
```bash
make lint
```
