### PR TITLE
ci: Use very simple version matching pattern for release tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: create-release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: create-release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+*?'
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: create-release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - 'v*'
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,8 @@ name: create-release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*?'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 jobs:
   create-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Why
## Motivation
Currently the release workflow is not running at all when running commands like the below:
```bash
git tag v0.1.0 master
git push origin v0.1.0
```

## Issues
Fixes #5 

# What
## Changes
* Use trivial pattern for matching tags

## Testing
N/A
